### PR TITLE
[Discussion] Adding Visual Studio Live Share

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "ms-azuretools.vscode-cosmosdb",
         "ms-vscode.azurecli",
         "msazurermtools.azurerm-vscode-tools",
-        "PeterJausovec.vscode-docker"
+        "PeterJausovec.vscode-docker",
+        "MS-vsliveshare.vsliveshare"
     ]
 }


### PR DESCRIPTION
This PR proposes adding the [Visual Studio Live Share](aka.ms/vsls) extension to this extension pack, since it has been optimized for Node.js collaborative development/remote pair programming, and is also very complimentary to many of the Azure extensions (e.g. you can collaboratively debug a Node.js function).

// CC @chrisdias 